### PR TITLE
core: use rbtree to store groups list

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-elliptics (2.26.3.33-3) unstable; urgency=low
+elliptics (2.26.3.33-5) unstable; urgency=low
 
   * logs: fixed printing trace_id at logs while receiving/sending packets.
   * core: use rbtree to store groups list.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+elliptics (2.26.3.33-3) unstable; urgency=low
+
+  * logs: fixed printing trace_id at logs while receiving/sending packets.
+  * core: use rbtree to store groups list.
+
+ -- Anton Kortunov <toshik@yandex-team.ru>  Wed, 04 Mar 2015 16:39:07 +0400
+
 elliptics (2.26.3.33-2) unstable; urgency=low
 
   * dependencies: updated eblob version

--- a/elliptics-bf.spec
+++ b/elliptics-bf.spec
@@ -3,7 +3,7 @@
 
 Summary:	Distributed hash table storage
 Name:		elliptics
-Version:	2.26.3.33-2
+Version:	2.26.3.33-3
 Release:	1%{?dist}
 
 License:	GPLv2+
@@ -143,6 +143,10 @@ rm -rf %{buildroot}
 
 
 %changelog
+* Wed Mar 04 2015 Anton Kortunov <toshik@yandex-team.ru> - 2.26.3.33-3
+- logs: fixed printing trace_id at logs while receiving/sending packets.
+- core: use rbtree to store groups list.
+
 * Fri Dec 05 2014 Kirill Smorodinnikov <shaitkir@gmail.com> - 2.26.3.33-2
 - dependencies: updated eblob version
 

--- a/elliptics-bf.spec
+++ b/elliptics-bf.spec
@@ -3,7 +3,7 @@
 
 Summary:	Distributed hash table storage
 Name:		elliptics
-Version:	2.26.3.33-3
+Version:	2.26.3.33-5
 Release:	1%{?dist}
 
 License:	GPLv2+

--- a/library/dnet.c
+++ b/library/dnet.c
@@ -1162,6 +1162,7 @@ int dnet_send_read_data(void *state, struct dnet_cmd *cmd, struct dnet_io_attr *
 
 	c->size = sizeof(struct dnet_io_attr) + io->size;
 	c->trans = cmd->trans;
+	c->trace_id = cmd->trace_id;
 	c->cmd = DNET_CMD_READ;
 	c->backend_id = cmd->backend_id;
 

--- a/library/dnet_common.c
+++ b/library/dnet_common.c
@@ -1,5 +1,6 @@
 /*
  * Copyright 2008+ Evgeniy Polyakov <zbr@ioremap.net>
+ * Copyright 2015+ Yandex
  *
  * This file is part of Elliptics.
  * 
@@ -620,6 +621,7 @@ int dnet_request_cmd(struct dnet_session *s, struct dnet_trans_control *ctl)
 	int num = 0;
 	struct dnet_net_state *st;
 	struct dnet_idc *idc;
+	struct rb_node *it;
 	struct dnet_group *g;
 	struct timeval start, end;
 	long diff;
@@ -627,7 +629,8 @@ int dnet_request_cmd(struct dnet_session *s, struct dnet_trans_control *ctl)
 	gettimeofday(&start, NULL);
 
 	pthread_mutex_lock(&n->state_lock);
-	list_for_each_entry(g, &n->group_list, group_entry) {
+	for (it = rb_first(&n->group_root); it; it = rb_next(it)) {
+		g = rb_entry(it, struct dnet_group, group_entry);
 		list_for_each_entry(idc, &g->idc_list, group_entry) {
 			st = idc->st;
 			if (st == n->st)

--- a/library/elliptics.h
+++ b/library/elliptics.h
@@ -1,5 +1,6 @@
 /*
  * Copyright 2008+ Evgeniy Polyakov <zbr@ioremap.net>
+ * Copyright 2015+ Yandex
  *
  * This file is part of Elliptics.
  *
@@ -360,9 +361,10 @@ void dnet_notify_exit(struct dnet_node *n);
 
 struct dnet_group
 {
-	struct list_head	group_entry;
+	struct rb_node		group_entry;
 
 	unsigned int		group_id;
+	struct dnet_node	*node;
 
 	struct list_head	idc_list;
 
@@ -567,7 +569,7 @@ struct dnet_node
 	struct dnet_addr	*addrs;
 
 	pthread_mutex_t		state_lock;
-	struct list_head	group_list;
+	struct rb_root		group_root;
 
 	/* hosts client states, i.e. those who didn't join network */
 	struct list_head	empty_state_list;

--- a/library/net.c
+++ b/library/net.c
@@ -1275,6 +1275,7 @@ int dnet_send_request(struct dnet_net_state *st, struct dnet_io_req *r)
 		struct dnet_cmd *cmd = r->header;
 		if (!cmd)
 			cmd = r->data;
+		dnet_node_set_trace_id(st->n->log, cmd->trace_id, cmd->flags & DNET_FLAGS_TRACE_BIT, (ssize_t)-1);
 		dnet_log(st->n, DNET_LOG_DEBUG, "%s: %s: sending -> %s: trans: %lld, size: %llu, cflags: %s, start-sent: %zd/%zd.",
 			dnet_dump_id(&cmd->id), dnet_cmd_string(cmd->cmd), dnet_addr_string(&st->addr),
 			(unsigned long long)cmd->trans,
@@ -1325,6 +1326,7 @@ err_out_exit:
 			(unsigned long long)cmd->size, dnet_flags_dump_cflags(cmd->flags),
 			st->send_offset, r->dsize + r->hsize + r->fsize);
 	}
+	dnet_node_unset_trace_id();
 
 	if (total_size > sizeof(struct dnet_cmd)) {
 		cork = 0;

--- a/library/net.cpp
+++ b/library/net.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright 2008+ Evgeniy Polyakov <zbr@ioremap.net>
  * Copyright 2014+ Ruslan Nigmatullin <euroelessar@yandex.ru>
+ * Copyright 2015+ Yandex
  *
  * This file is part of Elliptics.
  *
@@ -1197,8 +1198,10 @@ static net_state_list_ptr dnet_check_route_table_victims(struct dnet_node *node,
 	size_t groups_count = 0;
 	pthread_mutex_lock(&node->state_lock);
 
+	struct rb_node *it;
 	struct dnet_group *g;
-	list_for_each_entry(g, &node->group_list, group_entry) {
+	for (it = rb_first(&node->group_root); it; it = rb_next(it)) {
+		g = rb_entry(it, struct dnet_group, group_entry);
 		groups[groups_count++] = g->group_id;
 
 		if (groups_count >= groups_count_limit)

--- a/library/node.c
+++ b/library/node.c
@@ -1,5 +1,6 @@
 /*
  * Copyright 2008+ Evgeniy Polyakov <zbr@ioremap.net>
+ * Copyright 2015+ Yandex
  *
  * This file is part of Elliptics.
  * 
@@ -80,7 +81,7 @@ static struct dnet_node *dnet_node_alloc(struct dnet_config *cfg)
 	}
 	pthread_attr_setdetachstate(&n->attr, PTHREAD_CREATE_DETACHED);
 
-	INIT_LIST_HEAD(&n->group_list);
+	n->group_root = RB_ROOT;
 	INIT_LIST_HEAD(&n->empty_state_list);
 	INIT_LIST_HEAD(&n->dht_state_list);
 	INIT_LIST_HEAD(&n->storage_state_list);
@@ -106,7 +107,7 @@ err_out_free:
 	return NULL;
 }
 
-static struct dnet_group *dnet_group_create(unsigned int group_id)
+static struct dnet_group *dnet_group_create(struct dnet_node *n, unsigned int group_id)
 {
 	struct dnet_group *g;
 
@@ -118,6 +119,7 @@ static struct dnet_group *dnet_group_create(unsigned int group_id)
 
 	atomic_init(&g->refcnt, 1);
 	g->group_id = group_id;
+	g->node = n;
 
 	INIT_LIST_HEAD(&g->idc_list);
 
@@ -133,23 +135,54 @@ void dnet_group_destroy(struct dnet_group *g)
 		fprintf(stderr, "BUG in dnet_group_destroy, reference leak.");
 		exit(-1);
 	}
-	list_del(&g->group_entry);
+	rb_erase(&g->group_entry, &g->node->group_root);
 	free(g->ids);
 	free(g);
 }
 
 static struct dnet_group *dnet_group_search(struct dnet_node *n, unsigned int group_id)
 {
-	struct dnet_group *g, *found = NULL;
+	struct rb_root *root = &n->group_root;
+	struct rb_node *it = root->rb_node;
+	struct dnet_group *g = NULL;
 
-	list_for_each_entry(g, &n->group_list, group_entry) {
-		if (g->group_id == group_id) {
-			found = dnet_group_get(g);
-			break;
-		}
+	while (it) {
+		g = rb_entry(it, struct dnet_group, group_entry);
+
+		if (g->group_id < group_id)
+			it = it->rb_left;
+		else if (g->group_id > group_id)
+			it = it->rb_right;
+		else
+			return dnet_group_get(g);
 	}
 
-	return found;
+	return NULL;
+}
+
+int dnet_group_insert_nolock(struct dnet_node *n, struct dnet_group *a)
+{
+	struct rb_root *root = &n->group_root;
+	struct rb_node **it = &root->rb_node, *parent = NULL;
+	struct dnet_group *g = NULL;
+
+	while (*it) {
+		parent = *it;
+
+		g = rb_entry(parent, struct dnet_group, group_entry);
+
+		if (g->group_id < a->group_id)
+			it = &parent->rb_left;
+		else if (g->group_id > a->group_id)
+			it = &parent->rb_right;
+		else
+			return -EEXIST;
+	}
+
+	rb_link_node(&a->group_entry, parent, it);
+	rb_insert_color(&a->group_entry, root);
+
+	return 0;
 }
 
 static int dnet_idc_compare(const void *k1, const void *k2)
@@ -276,11 +309,13 @@ int dnet_idc_update_backend(struct dnet_net_state *st, struct dnet_backend_ids *
 
 	g = dnet_group_search(n, group_id);
 	if (!g) {
-		g = dnet_group_create(group_id);
+		g = dnet_group_create(n, group_id);
 		if (!g)
 			goto err_out_unlock;
 
-		list_add_tail(&g->group_entry, &n->group_list);
+		err = dnet_group_insert_nolock(n, g);
+		if (err)
+			goto err_out_unlock;
 	}
 
 	dnet_idc_remove_backend_nolock(st, backend->backend_id);

--- a/library/pool.c
+++ b/library/pool.c
@@ -370,6 +370,7 @@ static int dnet_process_recv_single(struct dnet_net_state *st)
 	uint64_t size;
 	int err;
 
+	dnet_node_set_trace_id(n->log, st->rcv_cmd.trace_id, st->rcv_cmd.flags & DNET_FLAGS_TRACE_BIT, (ssize_t)-1);
 again:
 	/*
 	 * Reading command first.
@@ -401,6 +402,9 @@ again:
 			err = -ECONNRESET;
 			goto out;
 		}
+
+		dnet_node_unset_trace_id();
+		dnet_node_set_trace_id(n->log, st->rcv_cmd.trace_id, st->rcv_cmd.flags & DNET_FLAGS_TRACE_BIT, (ssize_t)-1);
 
 		st->rcv_offset += err;
 	}
@@ -457,12 +461,14 @@ again:
 	r->st = dnet_state_get(st);
 
 	dnet_schedule_io(n, r);
+	dnet_node_unset_trace_id();
 	return 0;
 
 out:
 	if (err != -EAGAIN && err != -EINTR)
 		dnet_schedule_command(st);
 
+	dnet_node_unset_trace_id();
 	return err;
 }
 


### PR DESCRIPTION
Simple linked list was used before. This change dramatically
decreases command execution time in case of large amount of groups (> 1000).