### PR TITLE
srw: localnode service

### DIFF
--- a/cocaine/include/cocaine/actor.hpp
+++ b/cocaine/include/cocaine/actor.hpp
@@ -1,0 +1,114 @@
+/*
+    Copyright (c) 2011-2013 Andrey Sibiryov <me@kobology.ru>
+    Copyright (c) 2011-2013 Other contributors as noted in the AUTHORS file.
+
+    This file is part of Cocaine.
+
+    Cocaine is free software; you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    Cocaine is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef COCAINE_ACTOR_HPP
+#define COCAINE_ACTOR_HPP
+
+#include "cocaine/common.hpp"
+
+#include "cocaine/asio/reactor.hpp"
+#include "cocaine/asio/tcp.hpp"
+
+#include "cocaine/messages.hpp"
+
+#include <list>
+#include <thread>
+
+namespace cocaine {
+
+class dispatch_t;
+
+class actor_t {
+    COCAINE_DECLARE_NONCOPYABLE(actor_t)
+
+    public:
+        actor_t(context_t& context, std::shared_ptr<io::reactor_t> reactor, std::unique_ptr<dispatch_t>&& dispatch);
+       ~actor_t();
+
+        void
+        run(std::vector<io::tcp::endpoint> endpoints);
+
+        void
+        terminate();
+
+    public:
+        auto
+        location() const -> std::vector<io::tcp::endpoint>;
+
+        dispatch_t&
+        dispatch();
+
+        typedef io::event_traits<io::locator::resolve>::result_type metadata_t;
+
+        metadata_t
+        metadata() const;
+
+        struct counters_t {
+            size_t channels;
+
+            // Memory usage per client connection.
+            std::map<io::tcp::endpoint, size_t> footprints;
+        };
+
+        counters_t
+        counters() const;
+
+    private:
+        void
+        on_connection(const std::shared_ptr<io::socket<io::tcp>>& socket);
+
+        void
+        on_message(int fd, const io::message_t& message);
+
+        void
+        on_failure(int fd, const std::error_code& ec);
+
+    private:
+        context_t& m_context;
+
+        const std::unique_ptr<logging::log_t> m_log;
+        const std::shared_ptr<io::reactor_t> m_reactor;
+
+        // Actor I/O channels
+
+        struct lockable_t;
+        struct upstream_t;
+
+        std::map<
+            int,
+            std::shared_ptr<lockable_t>
+        > m_channels;
+
+        std::unique_ptr<dispatch_t> m_dispatch;
+
+        // Actor I/O connectors
+
+        std::list<
+            io::connector<io::acceptor<io::tcp>>
+        > m_connectors;
+
+        // Execution context
+
+        std::unique_ptr<std::thread> m_thread;
+};
+
+} // namespace cocaine
+
+#endif

--- a/cocaine/include/cocaine/framework/services/localnode.hpp
+++ b/cocaine/include/cocaine/framework/services/localnode.hpp
@@ -1,0 +1,61 @@
+/*
+ * 2015+ Copyright (c) Ivan Chelyubeev <ivan.chelubeev@gmail.com>
+ * 2014 Copyright (c) Asier Gutierrez <asierguti@gmail.com>
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+#ifndef LOCALNODE_SERVICE_PROXY_HPP
+#define LOCALNODE_SERVICE_PROXY_HPP
+
+#include <cocaine/framework/service.hpp>
+
+#include "cocaine/idl/localnode.hpp"
+#include "cocaine/traits/localnode.hpp"
+
+namespace ioremap { namespace elliptics {
+
+using cocaine::framework::service_traits;
+
+//
+// Service proxy object.
+// Provides native interface to the remote service on the client side.
+//
+struct localnode_proxy : public cocaine::framework::service_t
+{
+	static const unsigned int version = cocaine::io::protocol<localnode_tag>::version::value;
+
+	localnode_proxy(std::shared_ptr<cocaine::framework::service_connection_t> connection)
+		: service_t(connection)
+	{
+		// pass
+	}
+
+	service_traits<localnode_interface::read>::future_type
+	read(const dnet_raw_id &id, const std::vector<int> &groups, uint64_t offset, uint64_t size) {
+		return call<localnode_interface::read>(id, groups, offset, size);
+	}
+
+	service_traits<localnode_interface::write>::future_type
+	write(const dnet_raw_id &id, const std::vector<int> &groups, const std::string &bytes, uint64_t offset)	{
+		return call<localnode_interface::write>(id, groups, bytes, offset);
+	}
+
+	service_traits<localnode_interface::lookup>::future_type
+	lookup(const dnet_raw_id &id, const std::vector<int> &groups) {
+		return call<localnode_interface::lookup>(id, groups);
+	}
+};
+
+}} // namespace ioremap::elliptics
+
+#endif // LOCALNODE_SERVICE_PROXY_HPP

--- a/cocaine/include/cocaine/idl/localnode.hpp
+++ b/cocaine/include/cocaine/idl/localnode.hpp
@@ -1,0 +1,101 @@
+/*
+ * 2015+ Copyright (c) Ivan Chelyubeev <ivan.chelubeev@gmail.com>
+ * 2014 Copyright (c) Asier Gutierrez <asierguti@gmail.com>
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+#ifndef LOCALNODE_SERVICE_INTERFACE_HPP
+#define LOCALNODE_SERVICE_INTERFACE_HPP
+
+#include <cocaine/rpc/protocol.hpp>
+#include <elliptics/packet.h>
+
+namespace ioremap { namespace elliptics {
+
+struct dnet_async_service_result {
+	dnet_addr addr;
+	dnet_file_info file_info;
+	std::string file_path;
+};
+
+struct localnode_tag;
+
+struct localnode_interface {
+
+	struct read {
+		typedef localnode_tag tag;
+
+		static const char* alias() { return "read"; }
+
+		typedef boost::mpl::list<
+			dnet_raw_id,
+			std::vector<int>,
+			uint64_t,
+			uint64_t
+		> tuple_type;
+
+		typedef std::string result_type;
+	};
+
+	struct write {
+		typedef localnode_tag tag;
+
+		static const char* alias() { return "write"; }
+
+		typedef boost::mpl::list<
+			dnet_raw_id,
+			std::vector<int>,
+			std::string,
+			uint64_t
+		> tuple_type;
+
+		typedef dnet_async_service_result result_type;
+	};
+
+	struct lookup {
+		typedef localnode_tag tag;
+
+		static const char* alias() { return "lookup"; }
+
+		typedef boost::mpl::list<
+			dnet_raw_id,
+			std::vector<int>
+		> tuple_type;
+
+		typedef dnet_async_service_result result_type;
+	};
+};
+
+}} // namespace ioremap::elliptics
+
+
+namespace cocaine { namespace io {
+
+using ioremap::elliptics::localnode_tag;
+using ioremap::elliptics::localnode_interface;
+
+template<>
+struct protocol<localnode_tag> {
+	typedef boost::mpl::int_<1>::type version;
+
+	typedef mpl::list<
+		localnode_interface::read,
+		localnode_interface::write,
+		localnode_interface::lookup
+	> type;
+};
+
+}} // namespace cocaine::io
+
+
+#endif // LOCALNODE_SERVICE_INTERFACE_HPP

--- a/cocaine/include/cocaine/traits/localnode.hpp
+++ b/cocaine/include/cocaine/traits/localnode.hpp
@@ -1,0 +1,219 @@
+/*
+ * 2015+ Copyright (c) Ivan Chelyubeev <ivan.chelubeev@gmail.com>
+ * 2014 Copyright (c) Asier Gutierrez <asierguti@gmail.com>
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+#ifndef LOCALNODE_SERIALIZATION_TRAITS_HPP
+#define LOCALNODE_SERIALIZATION_TRAITS_HPP
+
+#include <msgpack.hpp>
+#include <cocaine/traits.hpp>
+#include <elliptics/packet.h>
+#include <elliptics/utils.hpp>
+
+namespace cocaine { namespace io {
+
+template<>
+struct type_traits<ioremap::elliptics::data_pointer> {
+    template<class Stream>
+    static inline
+    void
+    pack(msgpack::packer<Stream>& packer, const ioremap::elliptics::data_pointer& v) {
+        packer.pack_raw(v.size());
+        packer.pack_raw_body(static_cast<const char *>(v.data()), v.size());
+    }
+};
+
+}}
+
+namespace msgpack {
+
+//
+// Msgpack serialization for structures used by service.
+//
+// Note: not using cocaine::io::type_traits<> here because input/output
+// operators are more universal.
+//
+
+// struct dnet_raw_id {
+//  uint8_t         id[DNET_ID_SIZE];
+// } __attribute__ ((packed));
+//
+// Defined in elliptics/packet.h.
+//
+template <typename Stream>
+inline msgpack::packer<Stream>& operator <<(msgpack::packer<Stream> &o, const dnet_raw_id &v)
+{
+    o.pack_array(1);
+    o.pack_raw(sizeof(v.id));
+    o.pack_raw_body(reinterpret_cast<const char *>(v.id), sizeof(v.id));
+    return o;
+}
+inline dnet_raw_id& operator >>(const msgpack::object &o, dnet_raw_id &v)
+{
+    if (o.type != msgpack::type::ARRAY || o.via.array.size != 1) {
+        throw msgpack::type_error();
+    }
+    {
+        const auto &f = o.via.array.ptr[0];
+        if (f.type != msgpack::type::RAW || f.via.raw.size != sizeof(v.id)) {
+            throw msgpack::type_error();
+        }
+        memcpy(&v.id, f.via.raw.ptr, sizeof(v.id));
+    }
+    return v;
+}
+
+// struct dnet_addr
+// {
+//  uint8_t         addr[DNET_ADDR_SIZE];
+//  uint16_t        addr_len;
+//  uint16_t        family;
+// } __attribute__ ((packed));
+//
+// Defined in elliptics/packet.h.
+//
+template <typename Stream>
+inline msgpack::packer<Stream>& operator <<(msgpack::packer<Stream> &o, const dnet_addr &v)
+{
+    o.pack_array(3);
+    o.pack_raw(sizeof(v.addr));
+    o.pack_raw_body(reinterpret_cast<const char *>(v.addr), sizeof(v.addr));
+    o.pack_uint16(v.addr_len);
+    o.pack_uint16(v.family);
+    return o;
+}
+inline dnet_addr& operator >>(const msgpack::object &o, dnet_addr &v)
+{
+    if (o.type != msgpack::type::ARRAY || o.via.array.size != 3) {
+        throw msgpack::type_error();
+    }
+    {
+        const auto &f = o.via.array.ptr[0];
+        if (f.type != msgpack::type::RAW || f.via.raw.size != sizeof(v.addr)) {
+            throw msgpack::type_error();
+        }
+        memcpy(&v.addr, f.via.raw.ptr, sizeof(v.addr));
+    }
+    v.addr_len = o.via.array.ptr[1].as<uint16_t>();
+    v.family = o.via.array.ptr[2].as<uint16_t>();
+    return v;
+}
+
+// struct dnet_time {
+//  uint64_t        tsec, tnsec;
+// };
+//
+// Defined in elliptics/packet.h.
+//
+template <typename Stream>
+inline msgpack::packer<Stream>& operator <<(msgpack::packer<Stream> &o, const dnet_time &v)
+{
+    o.pack_array(2);
+    o.pack_uint64(v.tsec);
+    o.pack_uint64(v.tnsec);
+    return o;
+}
+inline dnet_time& operator >>(const msgpack::object &o, dnet_time &v)
+{
+    if (o.type != msgpack::type::ARRAY || o.via.array.size != 2) {
+        throw msgpack::type_error();
+    }
+    v.tsec = o.via.array.ptr[0].as<uint64_t>();
+    v.tnsec = o.via.array.ptr[1].as<uint64_t>();
+    return v;
+}
+
+// struct dnet_file_info {
+//  int         flen;       /* filename length, which goes after this structure */
+//  unsigned char       checksum[DNET_CSUM_SIZE];
+//
+//  uint64_t        record_flags;   /* combination of DNET_RECORD_FLAGS_* */
+//  uint64_t        size;       /* size of file on disk */
+//  uint64_t        offset;     /* offset of file on disk */
+//
+//  struct dnet_time    mtime;
+// };
+//
+// Defined in elliptics/packet.h.
+//
+template <typename Stream>
+inline msgpack::packer<Stream>& operator <<(msgpack::packer<Stream> &o, const dnet_file_info &v)
+{
+    o.pack_array(6);
+    // There is no actual need in keeping dnet_file_info::flen --
+    // -- its used to indicate length of file path tailing dnet_file_info
+    // objects in replies from elliptics node, but we handle that file path
+    // separately, so we could have dropped flen entirely.
+    // But still its better to keep it and thus support symmetricity of
+    // serialize/deserialize operations.
+    o.pack_int(v.flen);
+    o.pack_raw(sizeof(v.checksum));
+    o.pack_raw_body(reinterpret_cast<const char *>(v.checksum), sizeof(v.checksum));
+    o.pack_uint64(v.record_flags);
+    o.pack_uint64(v.size);
+    o.pack_uint64(v.offset);
+    o.pack(v.mtime);
+    return o;
+}
+inline dnet_file_info& operator >>(const msgpack::object &o, dnet_file_info &v)
+{
+    if (o.type != msgpack::type::ARRAY || o.via.array.size != 6) {
+        throw msgpack::type_error();
+    }
+    int N = 0;
+    o.via.array.ptr[N++] >> v.flen;
+    {
+        const auto &f = o.via.array.ptr[N++];
+        if (f.type != msgpack::type::RAW || f.via.raw.size != sizeof(v.checksum)) {
+            throw msgpack::type_error();
+        }
+        memcpy(&v.checksum, f.via.raw.ptr, sizeof(v.checksum));
+    }
+    o.via.array.ptr[N++] >> v.record_flags;
+    o.via.array.ptr[N++] >> v.size;
+    o.via.array.ptr[N++] >> v.offset;
+    o.via.array.ptr[N++] >> v.mtime;
+    return v;
+}
+
+// dnet_async_service_result
+//
+// Defined in cocaine/idl/localnode.hpp.
+//
+using ioremap::elliptics::dnet_async_service_result;
+
+template <typename Stream>
+inline msgpack::packer<Stream>& operator <<(msgpack::packer<Stream> &o, const dnet_async_service_result &v)
+{
+    o.pack_array(3);
+    o.pack(v.addr);
+    o.pack(v.file_info);
+    o.pack(v.file_path);
+    return o;
+}
+inline dnet_async_service_result& operator >>(const msgpack::object &o, dnet_async_service_result &v)
+{
+    if (o.type != msgpack::type::ARRAY || o.via.array.size != 3) {
+        throw msgpack::type_error();
+    }
+    o.via.array.ptr[0] >> v.addr;
+    o.via.array.ptr[1] >> v.file_info;
+    o.via.array.ptr[2] >> v.file_path;
+    return v;
+}
+
+} // namespace msgpack
+
+#endif // LOCALNODE_SERIALIZATION_TRAITS_HPP

--- a/srw/CMakeLists.txt
+++ b/srw/CMakeLists.txt
@@ -1,17 +1,12 @@
 include_directories(../library)
+include_directories(../cocaine/include)
 
 find_package(Msgpack REQUIRED)
 
-add_library(elliptics_cocaine STATIC srw.cpp)
-#set_target_properties(elliptics_cocaine PROPERTIES
-#    VERSION ${ELLIPTICS_VERSION}
-#    SOVERSION ${ELLIPTICS_VERSION_ABI}
-#    )
+add_library(elliptics_cocaine STATIC
+    srw.cpp
+    localnode.cpp
+)
+
 set_target_properties(elliptics_cocaine PROPERTIES COMPILE_FLAGS "-fPIC")
 target_link_libraries(elliptics_cocaine ${ELLIPTICS_LIBRARIES} ${MSGPACK_LIBRARIES})
-
-#install(TARGETS elliptics_cocaine
-#    LIBRARY DESTINATION lib${LIB_SUFFIX}
-#    ARCHIVE DESTINATION lib${LIB_SUFFIX}
-#    BUNDLE DESTINATION library
-#    )

--- a/srw/localnode.cpp
+++ b/srw/localnode.cpp
@@ -1,0 +1,217 @@
+/*
+ * 2015+ Copyright (c) Ivan Chelyubeev <ivan.chelubeev@gmail.com>
+ * 2014 Copyright (c) Asier Gutierrez <asierguti@gmail.com>
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+#include <sstream>
+
+#include <cocaine/context.hpp>
+#include <cocaine/logging.hpp>
+
+#include <elliptics/interface.h>
+
+#include "elliptics.h"
+
+#include "cocaine/idl/localnode.hpp"
+#include "cocaine/traits/localnode.hpp"
+#include "localnode.hpp"
+
+
+namespace {
+
+std::string to_string(const std::vector<int> &v)
+{
+    std::ostringstream ss;
+    for (size_t i = 0; i < v.size(); ++i) {
+        if (i > 0) {
+            ss << ", ";
+        }
+        ss << v[i];
+    }
+    return ss.str();
+}
+
+}
+
+
+namespace ioremap { namespace elliptics {
+
+using namespace std::placeholders;
+
+// Is there a better way to find groups that are served by this node?
+std::vector<int> find_local_groups(session &sess)
+{
+	const auto &routes = sess.get_routes();
+	const dnet_node *node = sess.get_native_node();
+	std::set<int> unique_groups;
+	for (const auto &route : routes) {
+		for (int i = 0; i < node->addr_num; ++i) {
+			if (dnet_addr_equal(&route.addr, &node->addrs[i])) {
+				unique_groups.insert(route.group_id);
+			}
+		}
+	}
+	return std::move(std::vector<int>(unique_groups.begin(), unique_groups.end()));
+}
+
+localnode::localnode(cocaine::context_t& context, cocaine::io::reactor_t& reactor, const std::string& name, const Json::Value& args, dnet_node* node)
+	: service_t(context, reactor, name, args)
+	, log_(context, name)
+	, session_proto_(node)
+{
+	COCAINE_LOG_DEBUG((&log_), "%s: enter", __func__);
+
+	on<localnode_interface::read>(localnode_interface::read::alias(),
+		std::bind(&localnode::read, this, _1, _2, _3, _4)
+	);
+	on<localnode_interface::write>(localnode_interface::write::alias(),
+		std::bind(&localnode::write, this, _1, _2, _3, _4)
+	);
+	on<localnode_interface::lookup>(localnode_interface::lookup::alias(),
+		std::bind(&localnode::lookup, this, _1, _2)
+	);
+
+	// find groups that are served by our node, and set them as session default
+	session_proto_.set_groups(find_local_groups(session_proto_));
+	COCAINE_LOG_INFO((&log_), "%s: found local groups: [%s]", __func__, to_string(session_proto_.get_groups()).c_str());
+
+	COCAINE_LOG_DEBUG((&log_), "%s: exit", __func__);
+}
+
+error_info override_groups(session &s, const std::vector<int> &groups)
+{
+	// special case: empty group list is only meaningful if node serve
+	// exactly single group, then is just a way to say:
+	// 'execute command against whatever group you serving'
+
+	if (groups.size() > 0)  {
+		s.set_groups(groups);
+
+	} else {
+		if (s.get_groups().size() > 1) {
+			return error_info(-6, "couldn't use group substitution on node which serve more then one group");
+		}
+	}
+	return error_info();
+}
+
+deferred<data_pointer> localnode::read(const dnet_raw_id &key, const std::vector<int> &groups, uint64_t offset, uint64_t size)
+{
+	COCAINE_LOG_DEBUG((&log_), "%s: enter", __func__);
+
+	deferred<data_pointer> promise;
+
+	auto s = session_proto_.clone();
+	s.set_exceptions_policy(session::no_exceptions);
+
+	if (auto error = override_groups(s, groups)) {
+		promise.abort(error.code(), error.message());
+		return promise;
+	}
+
+	COCAINE_LOG_INFO((&log_), "%s: proposed groups: [%s]", __func__, to_string(groups).c_str());
+	COCAINE_LOG_INFO((&log_), "%s: using groups: [%s]", __func__, to_string(s.get_groups()).c_str());
+
+	s.read_data(elliptics::key(key), offset, size).connect(
+		std::bind(&localnode::on_read_completed, this, promise, _1, _2)
+	);
+
+	COCAINE_LOG_DEBUG((&log_), "%s: exit", __func__);
+
+	return promise;
+}
+
+deferred<dnet_async_service_result> localnode::write(const dnet_raw_id &key, const std::vector<int> &groups, const std::string &bytes, uint64_t offset)
+{
+	COCAINE_LOG_DEBUG((&log_), "%s: enter", __func__);
+
+	deferred<dnet_async_service_result> promise;
+
+	auto s = session_proto_.clone();
+	s.set_exceptions_policy(ioremap::elliptics::session::no_exceptions);
+
+	if (auto error = override_groups(s, groups)) {
+		promise.abort(error.code(), error.message());
+		return promise;
+	}
+
+	s.write_data(elliptics::key(key), bytes, offset).connect(
+		std::bind(&localnode::on_write_completed, this, promise, _1, _2)
+	);
+
+	COCAINE_LOG_DEBUG((&log_), "%s: exit", __func__);
+
+	return promise;
+}
+
+deferred<dnet_async_service_result> localnode::lookup(const dnet_raw_id &key, const std::vector<int> &groups)
+{
+	deferred<dnet_async_service_result> promise;
+
+	auto s = session_proto_.clone();
+	s.set_exceptions_policy(ioremap::elliptics::session::no_exceptions);
+
+	if (auto error = override_groups(s, groups)) {
+		COCAINE_LOG_ERROR((&log_), "%s: return error %d, %s", __func__, error.code(), error.message());
+		promise.abort(error.code(), error.message());
+		return promise;
+	}
+
+	s.lookup(elliptics::key(key)).connect(
+		std::bind(&localnode::on_write_completed, this, promise, _1, _2)
+	);
+
+	return promise;
+}
+
+void localnode::on_read_completed(deferred<data_pointer> promise,
+		const std::vector<ioremap::elliptics::read_result_entry> &result,
+		const ioremap::elliptics::error_info &error)
+{
+	COCAINE_LOG_DEBUG((&log_), "%s: enter", __func__);
+
+	if (error) {
+		COCAINE_LOG_ERROR((&log_), "%s: return error %d, %s", __func__, error.code(), error.message());
+		promise.abort(error.code(), error.message());
+	} else {
+		promise.write(result[0].file());
+	}
+
+	COCAINE_LOG_DEBUG((&log_), "%s: exit", __func__);
+}
+
+void localnode::on_write_completed(deferred<dnet_async_service_result> promise,
+		const std::vector<ioremap::elliptics::lookup_result_entry> &results,
+		const ioremap::elliptics::error_info &error)
+{
+	COCAINE_LOG_DEBUG((&log_), "%s: enter", __func__);
+
+	if (error) {
+		COCAINE_LOG_ERROR((&log_), "%s: return error %d, %s", __func__, error.code(), error.message());
+		promise.abort(error.code(), error.message());
+	} else {
+		dnet_async_service_result r;
+		const auto &single_result = results[0];
+		r.addr = *single_result.storage_address();
+		r.file_info = *single_result.file_info();
+		r.file_path = single_result.file_path();
+		COCAINE_LOG_INFO((&log_), "%s: return success", __func__);
+		promise.write(r);
+	}
+
+	COCAINE_LOG_DEBUG((&log_), "%s: exit", __func__);
+}
+
+
+}} // namespace ioremap::elliptics

--- a/srw/localnode.hpp
+++ b/srw/localnode.hpp
@@ -1,0 +1,61 @@
+/*
+ * 2015+ Copyright (c) Ivan Chelyubeev <ivan.chelubeev@gmail.com>
+ * 2014 Copyright (c) Asier Gutierrez <asierguti@gmail.com>
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+#ifndef LOCALNODE_SERVICE_HPP
+#define LOCALNODE_SERVICE_HPP
+
+#include <cocaine/api/service.hpp>
+#include <elliptics/session.hpp>
+
+#include "cocaine/idl/localnode.hpp"
+
+namespace ioremap { namespace elliptics {
+
+using cocaine::deferred;
+
+//
+// Service implementation object.
+// This is the actual service working inside cocaine runtime.
+//
+class localnode : public cocaine::api::service_t
+{
+public:
+	localnode(cocaine::context_t &context, cocaine::io::reactor_t &reactor, const std::string &name, const Json::Value &args, dnet_node *node);
+
+private:
+	deferred<data_pointer> read(const dnet_raw_id &key, const std::vector<int> &groups, uint64_t offset, uint64_t size);
+	deferred<dnet_async_service_result> lookup(const dnet_raw_id &key, const std::vector<int> &groups);
+	deferred<dnet_async_service_result> write(const dnet_raw_id &key, const std::vector<int> &groups, const std::string &bytes, uint64_t offset);
+
+	void on_read_completed(deferred<data_pointer> promise,
+		const std::vector<ioremap::elliptics::read_result_entry> &result,
+		const ioremap::elliptics::error_info &error
+	);
+
+	void on_write_completed(deferred<dnet_async_service_result> promise,
+		const std::vector<ioremap::elliptics::lookup_result_entry> &result,
+		const ioremap::elliptics::error_info &error
+	);
+
+private:
+	cocaine::logging::log_t log_;
+
+	session session_proto_;
+};
+
+}} // namespace ioremap::elliptics
+
+#endif // LOCALNODE_SERVICE_HPP

--- a/tests/srw_test.cpp
+++ b/tests/srw_test.cpp
@@ -13,19 +13,86 @@
  * GNU Lesser General Public License for more details.
  */
 
-#include "srw_test.hpp"
-#include "test_base.hpp"
 #include <algorithm>
 
+#include <boost/program_options.hpp>
 #define BOOST_TEST_NO_MAIN
 #include <boost/test/included/unit_test.hpp>
 
-#include <boost/program_options.hpp>
+#include "elliptics/interface.h"
+
+// force cocaine templates to choose std's placeholders over boost's
+namespace cocaine { namespace io {
+	using std::placeholders::_1;
+	using std::placeholders::_2;
+}}
+#include "cocaine/framework/services/localnode.hpp"
+
+#include "test_base.hpp"
+#include "srw_test.hpp"
+
+namespace {
+
+std::string to_hex_string(const unsigned char * data, const size_t size)
+{
+	static const char hexchars[] = "0123456789abcdef";
+	std::string result;
+	result.reserve(size * 2);
+	for (size_t i = 0; i < size; ++i) {
+		const unsigned char byte = data[i];
+		result.push_back(hexchars[(byte >> 4) & 0x0f]);
+		result.push_back(hexchars[byte & 0x0f]);
+	}
+	return result;
+}
+
+std::string gen_random(const int len) {
+	static const char alphanum[] =
+		"0123456789"
+		"ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+		"abcdefghijklmnopqrstuvwxyz";
+
+	std::string result;
+	result.reserve(len);
+	for (int i = 0; i < len; ++i) {
+		result += alphanum[rand() % (sizeof(alphanum) - 1)];
+	}
+	return result;
+}
+
+}
+
+// required for localnode_test
+//
+namespace ioremap { namespace elliptics {
+
+inline bool operator==(const dnet_async_service_result &a, const dnet_async_service_result &b)
+{
+	return ((0 == dnet_addr_cmp(&a.addr, &b.addr))
+		&& (0 == memcmp(&a.file_info, &b.file_info, sizeof(a.file_info)))
+		&& a.file_path == b.file_path
+	);
+}
+
+inline std::ostream& operator<<(std::ostream& ostr, const dnet_async_service_result &v)
+{
+	ostr << "{\n addr=" << dnet_addr_string(&v.addr)
+		<< ",\n " << "record_flags=" << v.file_info.record_flags
+		<< ",\n " << "size=" << v.file_info.size
+		<< ",\n " << "time=" << dnet_print_time(&v.file_info.mtime)
+		<< ",\n " << "file=" << v.file_path
+		<< ",\n " << "checksum=" << to_hex_string(v.file_info.checksum, sizeof(v.file_info.checksum))
+		<< "\n}"
+		;
+	return ostr;
+}
+
+}}
+
+namespace tests {
 
 using namespace ioremap::elliptics;
 using namespace boost::unit_test;
-
-namespace tests {
 
 static std::shared_ptr<nodes_data> global_data;
 
@@ -171,7 +238,7 @@ static void timeout_test(session &sess, const std::string &app_name)
 		unsigned long max_diff = 2;
 
 		if (diff >= max_diff) {
-			printf("elapsed: %lld.%lld, timeout: %d, diff: %ld, must be less than %ld, error: %s [%d]\n", 
+			printf("elapsed: %lld.%lld, timeout: %d, diff: %ld, must be less than %ld, error: %s [%d]\n",
 					(unsigned long long)elapsed.tsec, (unsigned long long)elapsed.tnsec, it->first,
 					diff, max_diff,
 					res.error().message().c_str(), res.error().code());
@@ -179,6 +246,125 @@ static void timeout_test(session &sess, const std::string &app_name)
 			BOOST_REQUIRE_LE(elapsed.tsec - it->first, max_diff);
 		}
 	}
+}
+
+template<class T>
+T pack_unpack(const T &v)
+{
+	msgpack::sbuffer buf;
+	msgpack::pack(buf, v);
+
+	msgpack::unpacked msg;
+	msgpack::unpack(&msg, buf.data(), buf.size());
+
+	return msg.get().as<T>();
+}
+
+static void localnode_data_serialization_test()
+{
+	{
+		dnet_raw_id a = { "0123455678" };
+		dnet_raw_id b = pack_unpack(a);
+		BOOST_REQUIRE_EQUAL(std::string((const char *)a.id), std::string((const char *)b.id));
+	}
+	{
+		dnet_addr a = { "abc", 5, 8 };
+		dnet_addr b = pack_unpack(a);
+		BOOST_REQUIRE_EQUAL(a.addr_len, b.addr_len);
+		BOOST_REQUIRE_EQUAL(std::string((const char *)a.addr, a.addr_len), std::string((const char *)b.addr, b.addr_len));
+		BOOST_REQUIRE_EQUAL(a.family, b.family);
+	}
+	{
+		dnet_time a = { 5, 8 };
+		dnet_time b = pack_unpack(a);
+		BOOST_REQUIRE_EQUAL(a.tsec, b.tsec);
+		BOOST_REQUIRE_EQUAL(a.tnsec, b.tnsec);
+	}
+	{
+		dnet_file_info a = { 3, "abc", 5, 8, 10, { 2, 3} };
+		dnet_file_info b = pack_unpack(a);
+#define CMP(x) BOOST_REQUIRE_EQUAL(a.x, b.x)
+		CMP(flen);
+		CMP(record_flags);
+		CMP(size);
+		CMP(offset);
+		CMP(mtime.tsec);
+		CMP(mtime.tnsec);
+#undef CMP
+		BOOST_REQUIRE_EQUAL(
+			std::string((const char *)a.checksum, sizeof(a.checksum)),
+			std::string((const char *)b.checksum, sizeof(b.checksum))
+		);
+	}
+	{
+		dnet_async_service_result a = {
+			{ "abc", 5, 8 },
+			{ 3, "abc", 5, 8, 10, { 2, 3} },
+			"file path"
+		};
+		dnet_async_service_result b = pack_unpack(a);
+		BOOST_REQUIRE_EQUAL(a, b);
+	}
+}
+
+static void localnode_test(session &sess, const std::vector<int> &groups)
+{
+	using cocaine::framework::service_manager_t;
+
+	service_manager_t::endpoint_t endpoint("127.0.0.1", global_data->locator_port);
+	auto manager = service_manager_t::create(endpoint);
+
+	auto localnode = manager->get_service<localnode_proxy>("localnode");
+
+	key key(gen_random(8));
+	key.transform(sess);
+
+	auto value = gen_random(15);
+
+	dnet_async_service_result write_result;
+	dnet_async_service_result lookup_result;
+	{
+		auto &result = write_result;
+		auto deferred = localnode->write(key.raw_id(), groups, value, 0);
+		BOOST_REQUIRE_NO_THROW(result = deferred.next());
+		BOOST_REQUIRE_EQUAL(deferred.valid(), true);
+		BOOST_CHECK_GT(result.file_info.size, 0);
+		BOOST_CHECK_GT(result.file_path.size(), 0);
+	}
+	{
+		auto &result = lookup_result;
+		auto deferred = localnode->lookup(key.raw_id(), groups);
+		BOOST_REQUIRE_NO_THROW(result = deferred.next());
+		BOOST_REQUIRE_EQUAL(deferred.valid(), true);
+		BOOST_CHECK_GT(result.file_info.size, 0);
+		BOOST_CHECK_GT(result.file_path.size(), 0);
+	}
+
+	//XXX: can't compare write_result and lookup_result directly because
+	// file_info.size meaning and value differs for write and lookup operations
+	//BOOST_CHECK_EQUAL(write_result, lookup_result);
+	{
+		BOOST_CHECK_EQUAL(std::string((const char *)&write_result.addr, sizeof(dnet_addr)), std::string((const char *)&lookup_result.addr, sizeof(dnet_addr)));
+		BOOST_CHECK_EQUAL(write_result.file_path, lookup_result.file_path);
+#define CMP(x) BOOST_CHECK_EQUAL(write_result.file_info.x, lookup_result.file_info.x)
+		CMP(flen);
+		CMP(record_flags);
+		//CMP(size);
+		CMP(offset);
+		CMP(mtime.tsec);
+		CMP(mtime.tnsec);
+#undef CMP
+	}
+
+	std::string read_result;
+	{
+		auto &result = read_result;
+		auto deferred = localnode->read(key.raw_id(), groups, 0, 0);
+		BOOST_REQUIRE_NO_THROW(result = deferred.next());
+		BOOST_CHECK_GT(result.size(), 0);
+	}
+
+	BOOST_CHECK_EQUAL(read_result, value);
 }
 
 bool register_tests(test_suite *suite, node n)
@@ -191,6 +377,13 @@ bool register_tests(test_suite *suite, node n)
 	ELLIPTICS_TEST_CASE(send_response, create_session(n, { 1 }, 0, 0), application_name(), "some-data");
 	ELLIPTICS_TEST_CASE(send_response, create_session(n, { 1 }, 0, 0), application_name(), "some-data and long-data.. like this");
 	ELLIPTICS_TEST_CASE(timeout_test, create_session(n, { 1 }, 0, 0), application_name());
+
+	ELLIPTICS_TEST_CASE(localnode_data_serialization_test);
+
+	// localnode methods test,
+	// first using matching group_id, then empty group list
+	ELLIPTICS_TEST_CASE(localnode_test, create_session(n, {1}, 0, 0), std::vector<int>{1});
+	ELLIPTICS_TEST_CASE(localnode_test, create_session(n, {1}, 0, 0), std::vector<int>{});
 
 	return true;
 }

--- a/tests/srw_test.hpp
+++ b/tests/srw_test.hpp
@@ -5,6 +5,8 @@
 #include <msgpack.hpp>
 #include "test_base.hpp"
 
+#include <stdlib.h>
+
 #ifndef BOOST_REQUIRE_EQUAL
 # define BOOST_REQUIRE_EQUAL(a, b) do { \
 		if ((a) != (b)) { \


### PR DESCRIPTION
Localnode is a cocaine service built in srw. Internally it directly
uses server's node and (through a very simplified interface) gives
access to basic data operations without the need to use and configure
the actual elliptics client.

In essence, localnode service is an another entry point for clients
that use cocaine channel and protocol.